### PR TITLE
Default to raspberry pi target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,6 @@
+[build]
+target = "aarch64-unknown-linux-gnu"
+
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc-10"
+

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,5 @@
+[build]
+default-target = "aarch64-unknown-linux-gnu"
+
 [target.aarch64-unknown-linux-gnu]
 image = "thedevminertv/slimevr-testing-jig-buildbox:arm64"


### PR DESCRIPTION
I think you should default to the rpi target in these files. That being said, is this actually the rpi target? It didn't seem like it was actually. I thought rpi was armv7